### PR TITLE
Added check for empty phone record on employee

### DIFF
--- a/app/Filament/Pages/EmployeeWidgets/Employees.php
+++ b/app/Filament/Pages/EmployeeWidgets/Employees.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Eloquent\Builder;
 
 class Employees extends PageWidget
 {
-    
+
     protected int | string | array $columnSpan = [
         'md' => 2,
         'xl' => 3,
@@ -32,7 +32,7 @@ class Employees extends PageWidget
             Tables\Columns\TextColumn::make('name')->sortable()->searchable(),
             Tables\Columns\ImageColumn::make('photo')->size(40),
             Tables\Columns\TextColumn::make('email'),
-            Tables\Columns\TextColumn::make('phone')->formatStateUsing(fn ($record) => vsprintf('(%d%d%d) %d%d%d-%d%d%d%d', str_split($record->phone))),
+            Tables\Columns\TextColumn::make('phone')->formatStateUsing(fn ($record) => ($record->phone != '') ? vsprintf('(%d%d%d) %d%d%d-%d%d%d%d', str_split($record->phone)) : '-'),
             Tables\Columns\TextColumn::make('address'),
             Tables\Columns\BooleanColumn::make('active')->trueIcon('heroicon-o-badge-check')->falseIcon('heroicon-o-x-circle'),
         ];
@@ -70,7 +70,7 @@ class Employees extends PageWidget
                 Forms\Components\TextInput::make('address')->maxLength(250),
                 Forms\Components\Toggle::make('active')->default(true),
             ]),
-            
+
             Tables\Actions\EditAction::make()
             ->form([
                 Forms\Components\Select::make('company_id')


### PR DESCRIPTION
When creating an employee, the phone number is not required, but the table was throwing an error for empty values.

Pint also ran on save for this file cleaning up some white space.