### PR TITLE
fixed a bug in translation of plural words for the Arabic language

### DIFF
--- a/app/Filament/Company/Resources/Banking/AccountResource.php
+++ b/app/Filament/Company/Resources/Banking/AccountResource.php
@@ -28,6 +28,8 @@ class AccountResource extends Resource
 
     protected static ?string $modelLabel = 'Account';
 
+    protected static ?string $pluralModelLabel  = 'Accounts';
+
     protected static ?string $navigationIcon = 'heroicon-o-credit-card';
 
     protected static ?string $navigationGroup = 'Banking';
@@ -37,6 +39,13 @@ class AccountResource extends Resource
         $modelLabel = static::$modelLabel;
 
         return translate($modelLabel);
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        $pluralModelLabel = static::$pluralModelLabel;
+
+        return translate($pluralModelLabel);
     }
 
     public static function getNavigationParentItem(): ?string

--- a/app/Filament/Company/Resources/Core/DepartmentResource.php
+++ b/app/Filament/Company/Resources/Core/DepartmentResource.php
@@ -19,6 +19,8 @@ class DepartmentResource extends Resource
 
     protected static ?string $modelLabel = 'Department';
 
+    protected static ?string $pluralModelLabel = 'Departments';
+
     protected static ?string $navigationIcon = 'heroicon-o-square-3-stack-3d';
 
     protected static ?string $navigationGroup = 'HR';
@@ -30,6 +32,13 @@ class DepartmentResource extends Resource
         $modelLabel = static::$modelLabel;
 
         return translate($modelLabel);
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        $pluralModelLabel = static::$pluralModelLabel;
+
+        return translate($pluralModelLabel);
     }
 
     public static function getNavigationParentItem(): ?string

--- a/app/Filament/Company/Resources/Setting/CategoryResource.php
+++ b/app/Filament/Company/Resources/Setting/CategoryResource.php
@@ -25,6 +25,8 @@ class CategoryResource extends Resource
 
     protected static ?string $modelLabel = 'Category';
 
+    protected static ?string $pluralModelLabel  = 'Categories';
+
     protected static ?string $navigationIcon = 'heroicon-o-folder';
 
     protected static ?string $navigationGroup = 'Settings';
@@ -36,6 +38,13 @@ class CategoryResource extends Resource
         $modelLabel = static::$modelLabel;
 
         return translate($modelLabel);
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        $pluralModelLabel = static::$pluralModelLabel;
+
+        return translate($pluralModelLabel);
     }
 
     public static function getNavigationParentItem(): ?string

--- a/app/Filament/Company/Resources/Setting/CurrencyResource.php
+++ b/app/Filament/Company/Resources/Setting/CurrencyResource.php
@@ -30,6 +30,8 @@ class CurrencyResource extends Resource
 
     protected static ?string $modelLabel = 'Currency';
 
+    protected static ?string $pluralModelLabel = 'Currencies';
+
     protected static ?string $navigationIcon = 'heroicon-o-currency-dollar';
 
     protected static ?string $navigationGroup = 'Settings';
@@ -41,6 +43,13 @@ class CurrencyResource extends Resource
         $modelLabel = static::$modelLabel;
 
         return translate($modelLabel);
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        $pluralModelLabel = static::$pluralModelLabel;
+
+        return translate($pluralModelLabel);
     }
 
     public static function getNavigationParentItem(): ?string

--- a/app/Filament/Company/Resources/Setting/DiscountResource.php
+++ b/app/Filament/Company/Resources/Setting/DiscountResource.php
@@ -29,6 +29,8 @@ class DiscountResource extends Resource
 
     protected static ?string $modelLabel = 'Discount';
 
+    protected static ?string $pluralModelLabel  = 'Discounts';
+
     protected static ?string $navigationIcon = 'heroicon-o-tag';
 
     protected static ?string $navigationGroup = 'Settings';
@@ -40,6 +42,13 @@ class DiscountResource extends Resource
         $modelLabel = static::$modelLabel;
 
         return translate($modelLabel);
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        $pluralModelLabel = static::$pluralModelLabel;
+
+        return translate($pluralModelLabel);
     }
 
     public static function getNavigationParentItem(): ?string

--- a/app/Filament/Company/Resources/Setting/TaxResource.php
+++ b/app/Filament/Company/Resources/Setting/TaxResource.php
@@ -26,6 +26,8 @@ class TaxResource extends Resource
 
     protected static ?string $modelLabel = 'Tax';
 
+    protected static ?string $pluralModelLabel  = 'Taxes';
+
     protected static ?string $navigationIcon = 'heroicon-o-receipt-percent';
 
     protected static ?string $navigationGroup = 'Settings';
@@ -37,6 +39,13 @@ class TaxResource extends Resource
         $modelLabel = static::$modelLabel;
 
         return translate($modelLabel);
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        $pluralModelLabel = static::$pluralModelLabel;
+
+        return translate($pluralModelLabel);
     }
 
     public static function getNavigationParentItem(): ?string

--- a/resources/data/lang/ar.json
+++ b/resources/data/lang/ar.json
@@ -229,5 +229,9 @@
     "Website": "الموقع الإلكتروني",
     "Resources": "الموارد",
     "Finance": "التمويل",
-    "Personalization": "التخصيص"
+    "Personalization": "التخصيص",
+    "Discounts": "الخصومات",
+    "Taxes": "الضرائب",
+    "Accounts": "الحسابات",
+    "Departments": "الأقسام"
 }

--- a/resources/data/lang/en.json
+++ b/resources/data/lang/en.json
@@ -229,5 +229,9 @@
     "Resources": "Resources",
     "Finance": "Finance",
     "Personalization": "Personalization",
-    "Company": "Company"
+    "Company": "Company",
+    "Discounts": "Discounts",
+    "Taxes": "Taxes",
+    "Accounts": "Accounts",
+    "Departments": "Departments"
 }


### PR DESCRIPTION
This PR fixes an issue in the resource labels for the Arabic language 

### Issue with translating plural labels adding the letter `s` after the Arabic label
![image](https://github.com/andrewdwallo/erpsaas/assets/76778937/1f9587f6-841a-4ca0-aae4-2d3a39480dc9) 
 
### The fix in this PR
![image](https://github.com/andrewdwallo/erpsaas/assets/76778937/8e1c4438-fed5-47c7-bff9-dd222e439233)

