### PR TITLE
fix #121

### DIFF
--- a/app/Filament/Company/Resources/Purchases/BillResource.php
+++ b/app/Filament/Company/Resources/Purchases/BillResource.php
@@ -148,15 +148,19 @@ class BillResource extends Resource
                                         $offeringId = $state;
                                         $offeringRecord = Offering::with(['purchaseTaxes', 'purchaseDiscounts'])->find($offeringId);
 
-                                        if ($offeringRecord) {
-                                            $set('description', $offeringRecord->description);
-                                            $set('unit_price', $offeringRecord->price);
-                                            $set('purchaseTaxes', $offeringRecord->purchaseTaxes->pluck('id')->toArray());
+                                        if (! $offeringRecord) {
+                                            return;
+                                        }
 
-                                            $discountMethod = DocumentDiscountMethod::parse($get('../../discount_method'));
-                                            if ($discountMethod->isPerLineItem()) {
-                                                $set('purchaseDiscounts', $offeringRecord->purchaseDiscounts->pluck('id')->toArray());
-                                            }
+                                        $unitPrice = CurrencyConverter::convertToFloat($offeringRecord->price, $get('../../currency_code') ?? CurrencyAccessor::getDefaultCurrency());
+
+                                        $set('description', $offeringRecord->description);
+                                        $set('unit_price', $unitPrice);
+                                        $set('purchaseTaxes', $offeringRecord->purchaseTaxes->pluck('id')->toArray());
+
+                                        $discountMethod = DocumentDiscountMethod::parse($get('../../discount_method'));
+                                        if ($discountMethod->isPerLineItem()) {
+                                            $set('purchaseDiscounts', $offeringRecord->purchaseDiscounts->pluck('id')->toArray());
                                         }
                                     }),
                                 Forms\Components\TextInput::make('description'),

--- a/app/Filament/Company/Resources/Sales/EstimateResource.php
+++ b/app/Filament/Company/Resources/Sales/EstimateResource.php
@@ -153,15 +153,19 @@ class EstimateResource extends Resource
                                         $offeringId = $state;
                                         $offeringRecord = Offering::with(['salesTaxes', 'salesDiscounts'])->find($offeringId);
 
-                                        if ($offeringRecord) {
-                                            $set('description', $offeringRecord->description);
-                                            $set('unit_price', $offeringRecord->price);
-                                            $set('salesTaxes', $offeringRecord->salesTaxes->pluck('id')->toArray());
+                                        if (! $offeringRecord) {
+                                            return;
+                                        }
 
-                                            $discountMethod = DocumentDiscountMethod::parse($get('../../discount_method'));
-                                            if ($discountMethod->isPerLineItem()) {
-                                                $set('salesDiscounts', $offeringRecord->salesDiscounts->pluck('id')->toArray());
-                                            }
+                                        $unitPrice = CurrencyConverter::convertToFloat($offeringRecord->price, $get('../../currency_code') ?? CurrencyAccessor::getDefaultCurrency());
+
+                                        $set('description', $offeringRecord->description);
+                                        $set('unit_price', $unitPrice);
+                                        $set('salesTaxes', $offeringRecord->salesTaxes->pluck('id')->toArray());
+
+                                        $discountMethod = DocumentDiscountMethod::parse($get('../../discount_method'));
+                                        if ($discountMethod->isPerLineItem()) {
+                                            $set('salesDiscounts', $offeringRecord->salesDiscounts->pluck('id')->toArray());
                                         }
                                     }),
                                 Forms\Components\TextInput::make('description'),

--- a/app/Filament/Company/Resources/Sales/InvoiceResource.php
+++ b/app/Filament/Company/Resources/Sales/InvoiceResource.php
@@ -167,15 +167,19 @@ class InvoiceResource extends Resource
                                         $offeringId = $state;
                                         $offeringRecord = Offering::with(['salesTaxes', 'salesDiscounts'])->find($offeringId);
 
-                                        if ($offeringRecord) {
-                                            $set('description', $offeringRecord->description);
-                                            $set('unit_price', $offeringRecord->price);
-                                            $set('salesTaxes', $offeringRecord->salesTaxes->pluck('id')->toArray());
+                                        if (! $offeringRecord) {
+                                            return;
+                                        }
 
-                                            $discountMethod = DocumentDiscountMethod::parse($get('../../discount_method'));
-                                            if ($discountMethod->isPerLineItem()) {
-                                                $set('salesDiscounts', $offeringRecord->salesDiscounts->pluck('id')->toArray());
-                                            }
+                                        $unitPrice = CurrencyConverter::convertToFloat($offeringRecord->price, $get('../../currency_code') ?? CurrencyAccessor::getDefaultCurrency());
+
+                                        $set('description', $offeringRecord->description);
+                                        $set('unit_price', $unitPrice);
+                                        $set('salesTaxes', $offeringRecord->salesTaxes->pluck('id')->toArray());
+
+                                        $discountMethod = DocumentDiscountMethod::parse($get('../../discount_method'));
+                                        if ($discountMethod->isPerLineItem()) {
+                                            $set('salesDiscounts', $offeringRecord->salesDiscounts->pluck('id')->toArray());
                                         }
                                     }),
                                 Forms\Components\TextInput::make('description'),

--- a/app/Filament/Company/Resources/Sales/RecurringInvoiceResource.php
+++ b/app/Filament/Company/Resources/Sales/RecurringInvoiceResource.php
@@ -137,15 +137,19 @@ class RecurringInvoiceResource extends Resource
                                         $offeringId = $state;
                                         $offeringRecord = Offering::with(['salesTaxes', 'salesDiscounts'])->find($offeringId);
 
-                                        if ($offeringRecord) {
-                                            $set('description', $offeringRecord->description);
-                                            $set('unit_price', $offeringRecord->price);
-                                            $set('salesTaxes', $offeringRecord->salesTaxes->pluck('id')->toArray());
+                                        if (! $offeringRecord) {
+                                            return;
+                                        }
 
-                                            $discountMethod = DocumentDiscountMethod::parse($get('../../discount_method'));
-                                            if ($discountMethod->isPerLineItem()) {
-                                                $set('salesDiscounts', $offeringRecord->salesDiscounts->pluck('id')->toArray());
-                                            }
+                                        $unitPrice = CurrencyConverter::convertToFloat($offeringRecord->price, $get('../../currency_code') ?? CurrencyAccessor::getDefaultCurrency());
+
+                                        $set('description', $offeringRecord->description);
+                                        $set('unit_price', $unitPrice);
+                                        $set('salesTaxes', $offeringRecord->salesTaxes->pluck('id')->toArray());
+
+                                        $discountMethod = DocumentDiscountMethod::parse($get('../../discount_method'));
+                                        if ($discountMethod->isPerLineItem()) {
+                                            $set('salesDiscounts', $offeringRecord->salesDiscounts->pluck('id')->toArray());
                                         }
                                     }),
                                 Forms\Components\TextInput::make('description'),

--- a/app/Utilities/Currency/CurrencyConverter.php
+++ b/app/Utilities/Currency/CurrencyConverter.php
@@ -88,6 +88,13 @@ class CurrencyConverter
         return money($amount, $currency)->getValue();
     }
 
+    public static function convertToFloat(string | float $amount, ?string $currency = null): float
+    {
+        $currency ??= CurrencyAccessor::getDefaultCurrency();
+
+        return money($amount, $currency, true)->getValue();
+    }
+
     public static function isValidAmount(?string $amount, ?string $currency = null): bool
     {
         $currency ??= CurrencyAccessor::getDefaultCurrency();


### PR DESCRIPTION
Fixes #121. The issue was that because we are using a regular numeric text input field, it only accepts a float value but the cast for the offering price was formatted when being set in `afterStateUpdated`.