### PR TITLE
Add group by company_id to InvoiceOverview and BillOverview to resolve group by SQL error

### DIFF
--- a/app/Filament/Company/Resources/Purchases/BillResource/Widgets/BillOverview.php
+++ b/app/Filament/Company/Resources/Purchases/BillResource/Widgets/BillOverview.php
@@ -32,6 +32,7 @@ class BillOverview extends EnhancedStatsOverviewWidget
             $averagePaymentTime = $this->getPageTableQuery()
                 ->whereNotNull('paid_at')
                 ->selectRaw('AVG(TIMESTAMPDIFF(DAY, date, paid_at)) as avg_days')
+                ->groupBy('company_id')
                 ->value('avg_days');
 
             $averagePaymentTimeFormatted = Number::format($averagePaymentTime ?? 0, maxPrecision: 1);

--- a/app/Filament/Company/Resources/Sales/InvoiceResource/Widgets/InvoiceOverview.php
+++ b/app/Filament/Company/Resources/Sales/InvoiceResource/Widgets/InvoiceOverview.php
@@ -78,6 +78,7 @@ class InvoiceOverview extends EnhancedStatsOverviewWidget
             $averagePaymentTime = $this->getPageTableQuery()
                 ->whereNotNull('paid_at')
                 ->selectRaw('AVG(TIMESTAMPDIFF(DAY, approved_at, paid_at)) as avg_days')
+                ->groupBy('company_id')
                 ->value('avg_days');
 
             $averagePaymentTimeFormatted = Number::format($averagePaymentTime ?? 0, maxPrecision: 1);


### PR DESCRIPTION
Add group by company_id to InvoiceOverview and BillOverview to resolve group by SQL error. See error below

Illuminate \ Database\ 
QueryException

SQLSTATE[42000]: Syntax error or access violation: 1140 Mixing of GROUP columns (MIN(),MAX(),COUNT(),...) with no GROUP columns is illegal if there is no GROUP BY clause
select
  AVG(TIMESTAMPDIFF(DAY, date, paid_at)) as avg_days
from
  `bills`
where
  `bills`.`company_id` in (1)
  and `paid_at` is not null
  and `bills`.`company_id` = 1
order by
  `due_date` asc
limit
  1