### PR TITLE
Remove tenant avatars for company switcher

### DIFF
--- a/resources/views/components/panel-shift-dropdown/company-switcher.blade.php
+++ b/resources/views/components/panel-shift-dropdown/company-switcher.blade.php
@@ -29,7 +29,6 @@
         icon="heroicon-m-check"
         icon-color="primary"
         :url="filament()->getUrl($currentTenant)"
-        :image="filament()->getTenantAvatarUrl($currentTenant)"
         :label="$currentTenantName"
     />
 @endif
@@ -38,7 +37,6 @@
         <x-panel-shift-dropdown.item
             :url="filament()->getUrl($tenant)"
             :label="filament()->getTenantName($tenant)"
-            :image="filament()->getTenantAvatarUrl($tenant)"
         />
     @endforeach
 @endif

--- a/resources/views/components/panel-shift-dropdown/item.blade.php
+++ b/resources/views/components/panel-shift-dropdown/item.blade.php
@@ -41,10 +41,10 @@
             >
                 @if($image)
                     <div class="{{ $imageClasses }}" style="background-image: url('{{ $image }}')"></div>
-                @else
+                @elseif($icon)
                     <div class="{{ $iconWrapperClasses }}">
                         <x-filament::icon
-                            :icon="$icon ?? 'heroicon-m-document-text'"
+                            :icon="$icon"
                             :class="$iconClasses"
                         />
                     </div>
@@ -65,10 +65,10 @@
         >
             @if($image)
                 <div class="{{ $imageClasses }}" style="background-image: url('{{ $image }}')"></div>
-            @else
+            @elseif($icon)
                 <div class="{{ $iconWrapperClasses }}">
                     <x-filament::icon
-                        :icon="$icon ?? 'heroicon-m-document-text'"
+                        :icon="$icon"
                         :class="$iconClasses"
                     />
                 </div>

--- a/resources/views/components/panel-shift-dropdown/panel.blade.php
+++ b/resources/views/components/panel-shift-dropdown/panel.blade.php
@@ -16,7 +16,7 @@
 
 <ul
     x-ref="{{ $panelId }}"
-    class="w-full p-2.5 list-none flex flex-col space-y-2 hide transition-class"
+    class="w-full p-2.5 list-none flex flex-col space-y-2 hide transition-class max-h-[75vh] overflow-y-auto"
 >
     {{ $slot }}
 </ul>


### PR DESCRIPTION
If you belong to a lot of companies then a duplicate query is made for each of them on each page load. The avatar isn't really necessary here.