### PR TITLE
[Address] Fix null state access by using nullsafe operator

### DIFF
--- a/app/Models/Common/Address.php
+++ b/app/Models/Common/Address.php
@@ -80,7 +80,7 @@ class Address extends Model
                 implode(', ', $street), // Street 1 & 2 on same line if both exist
                 implode(', ', array_filter([
                     $this->city,
-                    $this->state->name,
+                    $this->state?->name,
                     $this->postal_code,
                 ])),
             ]);


### PR DESCRIPTION
Prevent "Attempt to read property 'name' on null" error when an address has no state.   Replaced `$this->state->name` with `$this->state?->name` to allow safe access.