### PR TITLE
Beautify title on printing documents

### DIFF
--- a/app/Models/Accounting/Document.php
+++ b/app/Models/Accounting/Document.php
@@ -55,7 +55,7 @@ abstract class Document extends Model
                     'id' => $record->id,
                 ]);
 
-                $livewire->js("window.printPdf('{$url}')");
+                $livewire->js("window.printPdf('{$url}', '{$record::documentType()->getLabel()} #{$record->documentNumber()}'); ");
             });
     }
 

--- a/resources/js/custom-print.js
+++ b/resources/js/custom-print.js
@@ -1,5 +1,6 @@
 function printPdf(url, title) {
     if (title) {
+        document.body.setAttribute('originalTitle', document.title);
         document.title = title;
     }
 
@@ -13,6 +14,10 @@ function printPdf(url, title) {
 
     iframe.onload = function () {
         try {
+            iframe.contentWindow.addEventListener('afterprint', function () {
+                document.body.removeChild(iframe);
+                document.title = document.body.getAttribute('originalTitle') || document.title;
+            });
             iframe.contentWindow.print();
         } catch (e) {
             console.error('Error printing PDF:', e);


### PR DESCRIPTION
The `window.printPdf()` function already accepts a title parameter but I think it was never implemented.
Changes in `resoruces/js/custom-print.js` are to make sure the document title is reset after printing.