### PR TITLE
Set currentDate in generateDateRangeOptions() to end of month to allow for new FY in January

### DIFF
--- a/app/Services/DateRangeService.php
+++ b/app/Services/DateRangeService.php
@@ -42,7 +42,7 @@ class DateRangeService
             'Custom' => [],
         ];
 
-        $period = CarbonPeriod::create($earliestDate, '1 month', $currentDate);
+        $period = CarbonPeriod::create($earliestDate, '1 month', $currentDate->endOfMonth());
 
         foreach ($period as $date) {
             $options['Fiscal Year']['FY-' . $date->year] = $date->year;


### PR DESCRIPTION
When opening reports page in January, date dropdown selection does not show current fiscal year. Setting current date to end of month does the trick (and in my view does not break any other relations?)